### PR TITLE
CI refactor

### DIFF
--- a/.github/workflows/build_and_test_ubuntu.yml
+++ b/.github/workflows/build_and_test_ubuntu.yml
@@ -66,7 +66,7 @@ jobs:
 
   mypy:
     needs: [wic_install]
-    name: Run MyPy
+    name: MyPy Check Type Annotations
     runs-on: [self-hosted, linux]
     steps:
     - working-directory: ${{github.workspace}}
@@ -79,7 +79,7 @@ jobs:
 
   pylint:
     needs: [wic_install]
-    name: Run PyLint
+    name: PyLint Check Code Quality
     runs-on: [self-hosted, linux]
     steps:
     - working-directory: ${{github.workspace}}
@@ -88,18 +88,36 @@ jobs:
 
 # NOTE: Do NOT add coverage to PYPY CI runs https://github.com/tox-dev/tox/issues/2252
 
-  pytest_serial:
+  pytest_cwl_embedding_independence:
     needs: [wic_install]
-    name: Run PyTest Serial Tests
+    name: PyTest CWL Embedding Independence
     runs-on: [self-hosted, linux]
     steps:
     - working-directory: ${{github.workspace}}
-      run: pytest -m serial # --cov --cov-config=.coveragerc_serial
+      run: pytest -k test_cwl_embedding_independence # --cov --cov-config=.coveragerc_serial
+      # NOTE: This test MUST be run in serial! See is_isomorphic_with_timeout()
 
-  pytest_parallel:
-    needs: [wic_install, docker_pull]
-    name: Run PyTest Parallel Tests
+  pytest_inline_subworkflows:
+    needs: [wic_install]
+    name: PyTest Inline Subworkflows
     runs-on: [self-hosted, linux]
     steps:
     - working-directory: ${{github.workspace}}
-      run: pytest -m "not serial" --workers 4 # --cov --cov-config=.coveragerc_parallel
+      run: pytest -k test_inline_subworkflows # --cov --cov-config=.coveragerc_serial
+      # NOTE: This test MUST be run in serial! See is_isomorphic_with_timeout()
+
+  pytest_fuzzy_compile:
+    needs: [wic_install]
+    name: PyTest Fuzzy Compile Test
+    runs-on: [self-hosted, linux]
+    steps:
+    - working-directory: ${{github.workspace}}
+      run: pytest -k test_fuzzy_compile
+
+  pytest_run_examples:
+    needs: [wic_install, docker_pull]
+    name: Run PyTest Example Workflows
+    runs-on: [self-hosted, linux]
+    steps:
+    - working-directory: ${{github.workspace}}
+      run: pytest -k test_run_examples --workers 4 # --cov --cov-config=.coveragerc_parallel

--- a/.github/workflows/build_and_test_ubuntu.yml
+++ b/.github/workflows/build_and_test_ubuntu.yml
@@ -1,4 +1,4 @@
-name: Build And Run Test on Ubuntu
+name: Build And Run Test
 
 on:
   push:
@@ -8,65 +8,94 @@ on:
 env:
   BUILD_TYPE: Release
 
-jobs:
-  Build_and_Run_PyTest:
-    name: Build and Run PyTest
-    runs-on: [self-hosted, linux]
-    defaults:
-      run:
-        shell: bash -l {0}
+defaults:
+  run:
+    shell: bash -l {0}
 
+jobs:
+  checkout:
+    name: Checkout source code
+    runs-on: [self-hosted, linux]
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
 
+  conda_setup:
+    name: Setup conda
+    runs-on: [self-hosted, linux]
+    steps:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniconda-version: "latest"
         activate-environment: wic
         channels: conda-forge
         python-version: "3.*"
+    - working-directory: ${{github.workspace}}
+      run: conda init bash
 
-    - name: Install System Dependencies from Conda
+  conda_install:
+    needs: [checkout, conda_setup]
+    name: Install System Dependencies from Conda
+    runs-on: [self-hosted, linux]
+    steps:
 # The version of cwltool in apt (2.0.20200224214940) does not support CWL version 1.2
 #      run: sudo apt install cwltool
 # Use conda to install cwltool (version 3.1.20220224085855)
-      working-directory: ${{github.workspace}}
-      run: |
-        conda info
-        conda list
-        conda config --show-sources
-        conda config --show
-        ./conda_devtools.sh
+    - working-directory: ${{github.workspace}}
+      run: ./conda_devtools.sh
 
-    - name: Docker Pull
-      working-directory: ${{github.workspace}}
-      # For self-hosted runners, make sure the docker cache is up-to-date.
+  docker_pull:
+    needs: [checkout, conda_setup]
+    name: Docker pull
+    runs-on: [self-hosted, linux]
+    steps:
+    - working-directory: ${{github.workspace}}
       run: ./dockerPull.sh
+      # For self-hosted runners, make sure the docker cache is up-to-date.
 
-    - name: Install Workflow Inference Compiler
-      working-directory: ${{github.workspace}}
+  wic_install:
+    needs: [conda_install]
+    name: Install Workflow Inference Compiler
+    runs-on: [self-hosted, linux]
+    steps:
+    - working-directory: ${{github.workspace}}
       run: pip install ".[test]"
 
-    - name: Run MyPy
-      working-directory: ${{github.workspace}}
+  mypy:
+    needs: [wic_install]
+    name: Run MyPy
+    runs-on: [self-hosted, linux]
+    steps:
+    - working-directory: ${{github.workspace}}
+      run: mypy --no-incremental src/ tests/
       # NOTE: Do not use `mypy .` because then mypy will check both src/ and build/ causing:
       # src/wic/__init__.py: error: Duplicate module named "wic" (also at "./build/lib/wic/__init__.py")
       # NOTE: We need to use --no-incremental because there is a bug in mypy.
       # This bug most often occurs when using ruamel library.
       # See https://github.com/python/mypy/issues/12664
-      run: mypy --no-incremental src/ tests/
 
-    - name: Run PyLint
-      working-directory: ${{github.workspace}}
-      # NOTE: See fail-under threshold in .pylintrc
+  pylint:
+    needs: [wic_install]
+    name: Run PyLint
+    runs-on: [self-hosted, linux]
+    steps:
+    - working-directory: ${{github.workspace}}
       run: pylint src/ tests/
+      # NOTE: See fail-under threshold in .pylintrc
 
-    - name: Run PyTest Serial Tests
-      working-directory: ${{github.workspace}}
+  pytest_serial:
+    needs: [wic_install]
+    name: Run PyTest Serial Tests
+    runs-on: [self-hosted, linux]
+    steps:
+    - working-directory: ${{github.workspace}}
       run: pytest --cov -m serial --cov-config=.coveragerc_serial
 
-    - name: Run PyTest Parallel Tests
-      working-directory: ${{github.workspace}}
+  pytest_parallel:
+    needs: [wic_install, docker_pull]
+    name: Run PyTest Parallel Tests
+    runs-on: [self-hosted, linux]
+    steps:
+    - working-directory: ${{github.workspace}}
       run: pytest --cov -m "not serial" --workers 4 --cov-config=.coveragerc_parallel

--- a/.github/workflows/build_and_test_ubuntu.yml
+++ b/.github/workflows/build_and_test_ubuntu.yml
@@ -86,13 +86,15 @@ jobs:
       run: pylint src/ tests/
       # NOTE: See fail-under threshold in .pylintrc
 
+# NOTE: Do NOT add coverage to PYPY CI runs https://github.com/tox-dev/tox/issues/2252
+
   pytest_serial:
     needs: [wic_install]
     name: Run PyTest Serial Tests
     runs-on: [self-hosted, linux]
     steps:
     - working-directory: ${{github.workspace}}
-      run: pytest --cov -m serial --cov-config=.coveragerc_serial
+      run: pytest -m serial # --cov --cov-config=.coveragerc_serial
 
   pytest_parallel:
     needs: [wic_install, docker_pull]
@@ -100,4 +102,4 @@ jobs:
     runs-on: [self-hosted, linux]
     steps:
     - working-directory: ${{github.workspace}}
-      run: pytest --cov -m "not serial" --workers 4 --cov-config=.coveragerc_parallel
+      run: pytest -m "not serial" --workers 4 # --cov --cov-config=.coveragerc_parallel

--- a/.github/workflows/build_and_test_ubuntu.yml
+++ b/.github/workflows/build_and_test_ubuntu.yml
@@ -22,13 +22,15 @@ jobs:
         submodules: recursive
 
   conda_setup:
-    name: Setup conda
+    name: Setup conda / mamba
     runs-on: [self-hosted, linux]
     steps:
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        miniconda-version: "latest"
+        miniforge-variant: Mambaforge-pypy3
+        miniforge-version: latest
         activate-environment: wic
+        use-mamba: true
         channels: conda-forge
         python-version: "3.*"
     - working-directory: ${{github.workspace}}
@@ -36,7 +38,7 @@ jobs:
 
   conda_install:
     needs: [checkout, conda_setup]
-    name: Install System Dependencies from Conda
+    name: Install System Dependencies from Conda / Mamba
     runs-on: [self-hosted, linux]
     steps:
 # The version of cwltool in apt (2.0.20200224214940) does not support CWL version 1.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM ubuntu:22.04
 
-# Install miniconda
+# Install conda / mamba
 RUN apt-get update && apt-get install -y wget
-RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" && \
-    wget --quiet https://repo.continuum.io/miniconda/$MINICONDA && \
-    chmod +x $MINICONDA && \
-    ./$MINICONDA -b -p /miniconda && \
-    rm -f $MINICONDA
-ENV PATH /miniconda/bin:$PATH
+
+RUN CONDA="Mambaforge-pypy3-Linux-x86_64.sh" && \
+    wget --quiet https://github.com/conda-forge/miniforge/releases/latest/download/$CONDA && \
+    chmod +x $CONDA && \
+    ./$CONDA -b -p /mambaforge-pypy3 && \
+    rm -f $CONDA
+ENV PATH /mambaforge-pypy3/bin:$PATH
 
 # Install wic
 RUN apt-get install -y git

--- a/conda_devtools.sh
+++ b/conda_devtools.sh
@@ -53,3 +53,9 @@ pip install 'toil[cwl]'
 # ...
 # "ERROR: Failed building wheel for ruptures"
 $CONDA install -y -c conda-forge compilers
+
+# The ruptures library also needs openblas. Otherwise:
+# "../../scipy/meson.build:134:0: ERROR:
+#  Dependency lookup for OpenBLAS with method 'pkgconfig' failed:
+#  Pkg-config binary for machine 1 not found. Giving up."
+$CONDA install -y -c conda-forge openblas

--- a/conda_devtools.sh
+++ b/conda_devtools.sh
@@ -6,6 +6,11 @@ if [ $(which mamba) ]; then
     CONDA=mamba
 fi
 
+# pypy is ~2X faster than the regular python interpreter.
+# We need to install it first so the dependency solver installs it bundled with python 3.9
+# (pypy is not yet compatible with 3.10 and 3.11)
+$CONDA install -y -c conda-forge pypy
+
 # Comment out pymol-bundle because it conflicts with `pip install toil[cwl]` below.
 #mamba install -y -c conda-forge -c schrodinger pymol-bundle
 # If you want to use the GUI, also install

--- a/conda_devtools.sh
+++ b/conda_devtools.sh
@@ -23,7 +23,7 @@ $CONDA install -y -c conda-forge pypy
 #$CONDA install -y -c conda-forge -c michellab biosimspace
 # At runtime, CWL uses the Docker image jakefennick/biosimspace
 
-$CONDA install -y -c conda-forge nodejs graphviz openbabel mdanalysis
+$CONDA install -y -c conda-forge nodejs graphviz # openbabel mdanalysis
 # NOTE: cwltool needs nodejs for InlineJavascriptRequirement
 
 # "Warning: Could not load "/miniconda/bin/../lib/graphviz/libgvplugin_pango.so.6"

--- a/conda_devtools.sh
+++ b/conda_devtools.sh
@@ -1,5 +1,13 @@
+# NOTE: mamba is a drop-in replacement for conda, just much faster.
+# (i.e. You can replace mamba with conda below.)
+# See https://github.com/conda-forge/miniforge#mambaforge-pypy3
+CONDA=conda
+if [ $(which mamba) ]; then
+    CONDA=mamba
+fi
+
 # Comment out pymol-bundle because it conflicts with `pip install toil[cwl]` below.
-#conda install -y -c conda-forge -c schrodinger pymol-bundle
+#mamba install -y -c conda-forge -c schrodinger pymol-bundle
 # If you want to use the GUI, also install
 # pip install PyQt5
 # At runtime, CWL uses the Docker image jakefennick/scripts
@@ -7,28 +15,28 @@
 # Comment out biosimspace because it is a massive dependency,
 # and for the very limited use case of file format conversions, we don't use
 # enough of the API to justify installing it for IDE support.
-#conda install -y -c conda-forge -c michellab biosimspace
+#$CONDA install -y -c conda-forge -c michellab biosimspace
 # At runtime, CWL uses the Docker image jakefennick/biosimspace
 
-conda install -y -c conda-forge nodejs graphviz openbabel mdanalysis
+$CONDA install -y -c conda-forge nodejs graphviz openbabel mdanalysis
 # NOTE: cwltool needs nodejs for InlineJavascriptRequirement
 
 # "Warning: Could not load "/miniconda/bin/../lib/graphviz/libgvplugin_pango.so.6"
 #  - It was found, so perhaps one of its dependents was not.  Try ldd."
 # See https://github.com/conda-forge/graphviz-feedstock/issues/35#issuecomment-786368065
-conda install -y -c conda-forge xorg-libxrender
+$CONDA install -y -c conda-forge xorg-libxrender
 
 # NOTE: https://github.com/wearepal/data-science-types has been archived and is
 # no longer under active development. So most of the API is covered, but there
 # are some functions which are missing stubs.
-conda install -y -c conda-forge data-science-types
+$CONDA install -y -c conda-forge data-science-types
 
-conda install -y -c conda-forge wget
-conda install -y -c conda-forge zip # Not installed by default on ubuntu
+$CONDA install -y -c conda-forge wget
+$CONDA install -y -c conda-forge zip # Not installed by default on ubuntu
 
 # NOTE: The [cwl] extra installs an embedded cwltool within toil-cwl-runner.
 # You can NOT `conda install cwltool` and then `pip install toil` !
-conda install -y -c conda-forge pip
+$CONDA install -y -c conda-forge pip
 pip install 'toil[cwl]'
 
 # The ruptures library needs to compile its binary wheel during pip install
@@ -39,4 +47,4 @@ pip install 'toil[cwl]'
 # "#  include <stdlib.h>"
 # ...
 # "ERROR: Failed building wheel for ruptures"
-conda install -y -c conda-forge compilers
+$CONDA install -y -c conda-forge compilers

--- a/docs/installguide.md
+++ b/docs/installguide.md
@@ -180,5 +180,6 @@ These vscode extensions are recommended for developers:
 * Docker
 * CWL (Rabix/Benten)
 * Git Extension Pack
+* Github Actions (Mathieu Dutour)
 * autoDocstring
 * Protein Viewer


### PR DESCRIPTION
This PR reduces the CI time from ~1 hr to ~40 mins, by

1. Converting the linear pipeline into an explicit DAG using the `needs` syntax for more parallelism.
2. Uses `mamba` (if installed) instead of `conda`, while carefully allowing conda as a fallback (so users don't need to know about mamba vs conda, we don't need to modify the documentation, etc).
3. Uses `pypy` instead of the standard python interpreter (~2x faster). Note that `python` resolves to pypy, so no code changes are necessary.

One minor caveat is that regarding 1, there appears to be some kind of a race condition w.r.t. activating a conda/mamba environment that can occasionally cause spurious failures. See https://github.com/jfennick/workflow-inference-compiler/actions/runs/4386752919 for an example. However, if you simply re-run the action, it will typically succeed the second time. This appears to be an issue on the github / runner side, rather than an issue with the code in this PR.