### PR TITLE
add box_vector_lengths to gmx_editconf

### DIFF
--- a/cwl_adapters/gmx_editconf.cwl
+++ b/cwl_adapters/gmx_editconf.cwl
@@ -71,11 +71,20 @@ inputs:
     inputBinding:
       position: 5
       prefix: -box
+      
+  box_vector_angles:
+    type:
+      - "null"
+      - type: array
+        items: float
+    inputBinding:
+      position: 6
+      prefix: -angles  
 
   align_principal_axes:
     type: int? # Group number to align (0 == system)
     inputBinding:
-      position: 6
+      position: 7
       prefix: -princ
 
 outputs:

--- a/cwl_adapters/gmx_editconf.cwl
+++ b/cwl_adapters/gmx_editconf.cwl
@@ -52,23 +52,30 @@ inputs:
     default: system.g96
 
   distance_to_molecule:
-    type: float
+    type: float?
     inputBinding:
       position: 3
       prefix: -d
-    default: 1.0
 
   box_type:
-    type: string
+    type: string?
     inputBinding:
       position: 4
       prefix: -bt
-    default: cubic
+
+  box_vector_lengths:
+    type:
+      - "null"
+      - type: array
+        items: float
+    inputBinding:
+      position: 5
+      prefix: -box
 
   align_principal_axes:
     type: int? # Group number to align (0 == system)
     inputBinding:
-      position: 5
+      position: 6
       prefix: -princ
 
 outputs:

--- a/src/wic/compiler.py
+++ b/src/wic/compiler.py
@@ -393,7 +393,8 @@ def compile_workflow_once(yaml_tree_ast: YamlTree,
         # print(list(in_tool.keys()))
         if tool_i.cwl['class'] == 'CommandLineTool':
             args_required = [arg for arg in in_tool if not (in_tool[arg].get('default') or
-                                                            (isinstance(in_tool[arg]['type'], str) and in_tool[arg]['type'][-1] == '?'))]
+                                                            (isinstance(in_tool[arg]['type'], str) and in_tool[arg]['type'][-1] == '?') or
+                                                            (isinstance(in_tool[arg]['type'], List) and 'null' in in_tool[arg]['type']))]
         elif tool_i.cwl['class'] == 'Workflow':
             args_required = list(in_tool)
 

--- a/src/wic/compiler.py
+++ b/src/wic/compiler.py
@@ -393,6 +393,8 @@ def compile_workflow_once(yaml_tree_ast: YamlTree,
         # print(list(in_tool.keys()))
         if tool_i.cwl['class'] == 'CommandLineTool':
             args_required = [arg for arg in in_tool if not (in_tool[arg].get('default') or
+                                                            # Check for optional arguments using both the '?' syntactic sugar, as well as the
+                                                            # canonical null representation. See canonicalize_type in cwl_utils.py
                                                             (isinstance(in_tool[arg]['type'], str) and in_tool[arg]['type'][-1] == '?') or
                                                             (isinstance(in_tool[arg]['type'], List) and 'null' in in_tool[arg]['type']))]
         elif tool_i.cwl['class'] == 'Workflow':

--- a/src/wic/schemas/biobb.py
+++ b/src/wic/schemas/biobb.py
@@ -169,13 +169,32 @@ def biobb_editconf_schema() -> Json:
     box_type = {'type': 'string', 'enum': box_vals, 'description': desc}
     center_molecule = {'type': 'boolean', 'description': '(True) Center molecule in the box.'}
     box_vector_lengths = {'type': 'array', 'items': {'type': 'number'},
-                          'description': '(None) Array of floats defining the box vector lengths ie "0.5 0.5 0.5".'
-                          'If this option is used the distance_to_molecule property will be ignored.'}
+                          'description': """(None) Array of floats defining the box vector lengths ie "0.5 0.5 0.5".
+                          If this option is used the distance_to_molecule property will be ignored."""}
+    box_vector_angles = {'type': 'array', 'items': {'type': 'number'},
+                         'description': """(None) Array of floats defining the box vector angles ie "90 90 90".
+                         This option is only meaningful with "box_vector_lengths" option and when is used.
+                         the distance_to_molecule property will be ignored."""}
 
     schema = default_schema()
+    # Note: The `box_vector_lengths` can't be used with `box_type`` but
+    # the mutually exclusive option for schema doesn't work for now.
+    # schema['oneOf'] = [{'properties': {'box_vector_lengths':
+    #                     box_vector_lengths, },
+    #                     'required': ['box_vector_lengths'], },
+    #                    {'properties': {'box_type':
+    #                     box_type, },
+    #                     'required': ['box_type'], }]
+
     schema['properties'] = {'distance_to_molecule': distance_to_molecule,
-                            'box_type': box_type, 'center_molecule': center_molecule, 'box_vector_lengths': box_vector_lengths,
+                            'box_type': box_type,
+                            'center_molecule': center_molecule,
+                            'box_vector_lengths': box_vector_lengths,
+                            'box_vector_angles': box_vector_angles,
                             **biobb_container_schema()}
+
+    # schema['dependentRequired'] = {'box_vector_angles': ['box_vector_lengths'],
+    #                                'distance_to_molecule': ['box_type']}
     return schema
 
 

--- a/src/wic/schemas/biobb.py
+++ b/src/wic/schemas/biobb.py
@@ -168,10 +168,13 @@ def biobb_editconf_schema() -> Json:
     octahedron (truncated octahedron)."""
     box_type = {'type': 'string', 'enum': box_vals, 'description': desc}
     center_molecule = {'type': 'boolean', 'description': '(True) Center molecule in the box.'}
+    box_vector_lengths = {'type': 'array', 'items': {'type': 'number'},
+                          'description': '(None) Array of floats defining the box vector lengths ie "0.5 0.5 0.5".'
+                          'If this option is used the distance_to_molecule property will be ignored.'}
 
     schema = default_schema()
     schema['properties'] = {'distance_to_molecule': distance_to_molecule,
-                            'box_type': box_type, 'center_molecule': center_molecule,
+                            'box_type': box_type, 'center_molecule': center_molecule, 'box_vector_lengths': box_vector_lengths,
                             **biobb_container_schema()}
     return schema
 


### PR DESCRIPTION
Hello,

This PR adds an option to the `gmx_editconf` wrapper that enables the use of box vector lengths for setting up a system.

Thanks,
Nazanin