### PR TITLE
Change repo-dispatch payload name reference.

### DIFF
--- a/.github/workflows/branch_dispatch_repository_dispatch.yml
+++ b/.github/workflows/branch_dispatch_repository_dispatch.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: workflow-inference-compiler
           sender_repo_owner: ${{ github.event.client_payload.owner }}
-          sender_repo_ref: ${{ github.event.client_payload.ref_name }}
+          sender_repo_ref: ${{ github.event.client_payload.ref }}
           default_owner: PolusAI
           default_branch: master
           access_token: ${{ steps.generate_token.outputs.token }}
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: mm-workflows
           sender_repo_owner: ${{ github.event.client_payload.owner }}
-          sender_repo_ref: ${{ github.event.client_payload.ref_name }}
+          sender_repo_ref: ${{ github.event.client_payload.ref }}
           default_owner: PolusAI
           default_branch: main
           access_token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
- Fix the wrong variable reference. `mm-workflows` uses `ref` in the `client_payload` of `repository_dispatch` webhook, rather than `ref_name`. The wrong reference evaluated `sender_repo_ref` to `null` and makes the `wic_owner` & `mm_workflows_owner` to `PolusAI` and `wic_ref` (`mm_workflows_ref`) to `master` (`main`).