### PR TITLE
Fix weekly CI pytest names.

### DIFF
--- a/.github/workflows/run_workflows_weekly.yml
+++ b/.github/workflows/run_workflows_weekly.yml
@@ -111,7 +111,7 @@ jobs:
     - name: PyTest Run Inlined Workflows
       if: always()
       # NOTE: Do NOT add coverage to PYPY CI runs https://github.com/tox-dev/tox/issues/2252
-      run: cd wic/ && pytest -k test_run_inlined_workflows --workers 8 --cwl_runner toil-cwl-runner # --cov
+      run: cd wic/ && pytest -k "test_run_inlined_workflows and not weekly" --workers 8 --cwl_runner toil-cwl-runner # --cov
 
     - name: PyTest Run Workflows (Weekly)
       if: always()
@@ -121,4 +121,4 @@ jobs:
     - name: PyTest Run Inlined Workflows (Weekly)
       if: always()
       # NOTE: Do NOT add coverage to PYPY CI runs https://github.com/tox-dev/tox/issues/2252
-      run: cd wic/ && pytest -k test_run_inlined_workflows_weekly_inlined --workers 8 --cwl_runner toil-cwl-runner # --cov
+      run: cd wic/ && pytest -k test_run_inlined_workflows_weekly --workers 8 --cwl_runner toil-cwl-runner # --cov


### PR DESCRIPTION
In `pytest`, `-k` specifies an "expression" (or substring) instead of exact strings of unittest names. If we have two tests with names: `test_a` and `test_a_inlined`, running `pytest -k a` will run both tests since `a` is also a substring of `test_a_inlined`. 

Use `pytest -k "a not inlined"` to exclude the substring `inlined`.