### PR TITLE
Use inputs.wic_ref in concurrency judgement.

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -78,7 +78,7 @@ jobs:
     # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
     # This will prevent DOS attacks from people blasting the CI with rapid fire commits.
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.os }}-${{ github.ref }}-${{ inputs.sender_repo }}-${{ inputs.mm-workflows_ref}}
+      group: ${{ github.workflow }}-${{ matrix.os }}-${{ inputs.wic_ref }}-${{ inputs.sender_repo }}-${{ inputs.mm-workflows_ref}}
       cancel-in-progress: true
     strategy:
       fail-fast: false

--- a/.github/workflows/run_workflows.yml
+++ b/.github/workflows/run_workflows.yml
@@ -63,7 +63,7 @@ jobs:
     # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
     # This will prevent DOS attacks from people blasting the CI with rapid fire commits.
     concurrency:
-      group: ${{ github.workflow }}-cwltool-${{ github.ref }}-${{ inputs.sender_repo }}-${{ inputs.mm-workflows_ref}}
+      group: ${{ github.workflow }}-cwltool-${{ inputs.wic_ref }}-${{ inputs.sender_repo }}-${{ inputs.mm-workflows_ref}}
       cancel-in-progress: true
     runs-on: [self-hosted, linux]
 


### PR DESCRIPTION
Problem Description:
When two PRs are opened simultaneously on WIC, the latter one will kill the github actions from the first one. 

Reason:
This happens because actions from both PRs are running on the `master` branch of the PolusAI wic repo.

Fix:
Use the ref name of the incoming feature branch to differentiate PRs.