### PR TITLE
use repo name for relative paths

### DIFF
--- a/.github/workflows/fuzzy_compile_weekly.yml
+++ b/.github/workflows/fuzzy_compile_weekly.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/workflow-inference-compiler
           ref: master
-          path: wic
+          path: workflow-inference-compiler
 
       - name: Checkout biobb_adapters
         if: always()
@@ -65,7 +65,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge-pypy3
           miniforge-version: latest
-          environment-file: wic/install/system_deps.yml
+          environment-file: workflow-inference-compiler/install/system_deps.yml
           activate-environment: wic
           use-mamba: true
           channels: conda-forge
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install Workflow Inference Compiler
         if: always()
-        run: cd wic/ && pip install ".[all]"
+        run: cd workflow-inference-compiler/ && pip install ".[all]"
 
       - name: Install Molecular Modeling Workflows
         if: always()
@@ -87,31 +87,31 @@ jobs:
 # Since a randomly chosen subschema is used every time, repeat 10X for more coverage.
 
       - name: PyTest Fuzzy Compile
-        run: cd wic/ && pytest -k test_fuzzy_compile
+        run: cd workflow-inference-compiler/ && pytest -k test_fuzzy_compile
 
       - name: PyTest Fuzzy Compile
-        run: cd wic/ && pytest -k test_fuzzy_compile
+        run: cd workflow-inference-compiler/ && pytest -k test_fuzzy_compile
 
       - name: PyTest Fuzzy Compile
-        run: cd wic/ && pytest -k test_fuzzy_compile
+        run: cd workflow-inference-compiler/ && pytest -k test_fuzzy_compile
 
       - name: PyTest Fuzzy Compile
-        run: cd wic/ && pytest -k test_fuzzy_compile
+        run: cd workflow-inference-compiler/ && pytest -k test_fuzzy_compile
 
       - name: PyTest Fuzzy Compile
-        run: cd wic/ && pytest -k test_fuzzy_compile
+        run: cd workflow-inference-compiler/ && pytest -k test_fuzzy_compile
 
       - name: PyTest Fuzzy Compile
-        run: cd wic/ && pytest -k test_fuzzy_compile
+        run: cd workflow-inference-compiler/ && pytest -k test_fuzzy_compile
 
       - name: PyTest Fuzzy Compile
-        run: cd wic/ && pytest -k test_fuzzy_compile
+        run: cd workflow-inference-compiler/ && pytest -k test_fuzzy_compile
 
       - name: PyTest Fuzzy Compile
-        run: cd wic/ && pytest -k test_fuzzy_compile
+        run: cd workflow-inference-compiler/ && pytest -k test_fuzzy_compile
 
       - name: PyTest Fuzzy Compile
-        run: cd wic/ && pytest -k test_fuzzy_compile
+        run: cd workflow-inference-compiler/ && pytest -k test_fuzzy_compile
 
       - name: PyTest Fuzzy Compile
-        run: cd wic/ && pytest -k test_fuzzy_compile
+        run: cd workflow-inference-compiler/ && pytest -k test_fuzzy_compile

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           repository: ${{ inputs.wic_owner }}/workflow-inference-compiler
           ref: ${{ inputs.wic_ref }}
-          path: wic
+          path: workflow-inference-compiler
 
       - name: Checkout biobb_adapters
         if: always()
@@ -117,11 +117,11 @@ jobs:
       # NOTE: pypy actually decreases performance for lint_and_test.yml (by a factor of ~2)
       # - name: Append pypy to conda environment files
       #   if: runner.os != 'Windows'
-      #   run: cd wic/install/ && echo "  - pypy" >> system_deps.yml
+      #   run: cd workflow-inference-compiler/install/ && echo "  - pypy" >> system_deps.yml
 
       # - name: Append pypy to conda environment files
       #   if: runner.os == 'Windows'
-      #   run: cd wic/install/ && echo "  - pypy" >> system_deps_windows.yml
+      #   run: cd workflow-inference-compiler/install/ && echo "  - pypy" >> system_deps_windows.yml
 
       - name: Setup mamba (linux, macos)
         if: runner.os != 'Windows'
@@ -129,7 +129,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge-pypy3
           miniforge-version: latest
-          environment-file: wic/install/system_deps.yml
+          environment-file: workflow-inference-compiler/install/system_deps.yml
           activate-environment: wic
           use-mamba: true
           channels: conda-forge
@@ -140,7 +140,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
-          environment-file: wic/install/system_deps_windows.yml
+          environment-file: workflow-inference-compiler/install/system_deps_windows.yml
           activate-environment: wic
           channels: conda-forge
           python-version: "3.9.*" # pypy is not yet compatible with 3.10 and 3.11
@@ -148,11 +148,11 @@ jobs:
       - name: ShellCheck Script Quality
         if: always()
         # "SC1017 (error): Literal carriage return. Run script through tr -d '\r' ."
-        run: shellcheck -e SC1017 $(find wic/ -name "*.sh" -and -not -path "./3/*")
+        run: shellcheck -e SC1017 $(find workflow-inference-compiler/ -name "*.sh" -and -not -path "./3/*")
 
       - name: Install Workflow Inference Compiler
         if: always()
-        run: cd wic/ && pip install ".[all]"
+        run: cd workflow-inference-compiler/ && pip install ".[all]"
 
       - name: Install Molecular Modeling Workflows
         if: always()
@@ -165,23 +165,24 @@ jobs:
 
       - name: Build Documentation
         if: always()
-        run: cd wic/docs && make html
+        run: cd workflow-inference-compiler/docs && make html
 
       - name: MyPy Check Type Annotations
         if: always()
-        run: cd wic/ && mypy src/ examples/ tests/
+        run: cd workflow-inference-compiler/ && mypy src/ examples/ tests/
         # NOTE: Do not use `mypy .` because then mypy will check both src/ and build/ causing:
-        # src/wic/__init__.py: error: Duplicate module named "wic" (also at "./build/lib/wic/__init__.py")
+        # src/workflow-inference-compiler/__init__.py: error: Duplicate module named "wic"
+        # (also at "./build/lib/workflow-inference-compiler/__init__.py")
 
       - name: PyLint Check Code Quality
         if: always()
-        run: cd wic/ && pylint src/ examples/**/*.py tests/
+        run: cd workflow-inference-compiler/ && pylint src/ examples/**/*.py tests/
         # NOTE: See fail-under threshold in .pylintrc
 
       - name: PEP8 Code Formatting
         if: always()
         id: autopep8
-        run: cd wic/ && autopep8 --exit-code --recursive --diff --max-line-length 120 examples/ src/ tests/
+        run: cd workflow-inference-compiler/ && autopep8 --exit-code --recursive --diff --max-line-length 120 examples/ src/ tests/
       - name: Fail if autopep8 made changes
         if: steps.autopep8.outputs.exit-code == 2
         run: exit 1
@@ -190,13 +191,13 @@ jobs:
 
       - name: PyTest CWL Embedding Independence
         if: always()
-        run: cd wic/ && pytest -k test_cwl_embedding_independence # --cov --cov-config=.coveragerc_serial
+        run: cd workflow-inference-compiler/ && pytest -k test_cwl_embedding_independence # --cov --cov-config=.coveragerc_serial
         # NOTE: This test MUST be run in serial! See is_isomorphic_with_timeout()
         timeout-minutes: 5 # backup timeout for windows
 
       - name: PyTest Inline Subworkflows
         if: always()
-        run: cd wic/ && pytest -k test_inline_subworkflows # --cov --cov-config=.coveragerc_serial
+        run: cd workflow-inference-compiler/ && pytest -k test_inline_subworkflows # --cov --cov-config=.coveragerc_serial
         # NOTE: This test MUST be run in serial! See is_isomorphic_with_timeout()
         timeout-minutes: 5 # backup timeout for windows
 
@@ -205,7 +206,7 @@ jobs:
         # Avoid Windows and macOS due to 2X and 10X minute multipliers.
         # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers
         # Also, cannot run on Windows (natively) yet
-        run: cd wic/ && pytest -k test_scattering_scaling
+        run: cd workflow-inference-compiler/ && pytest -k test_scattering_scaling
 
       # NOTE: The steps below are for repository_dispatch only. For all other steps, please insert above
       # this comment.
@@ -243,7 +244,7 @@ jobs:
         # https://github.com/actions/runner/issues/834#issuecomment-907096707
         # Use inputs.sender_repo to reply the original sender.
         if: always()
-        uses: ./wic/.github/my_actions/reply_sender/ # Must start with ./
+        uses: ./workflow-inference-compiler/.github/my_actions/reply_sender/ # Must start with ./
         with:
           github_repository: ${{ github.repository }}
           event_type: ${{ inputs.event_type }}

--- a/.github/workflows/lint_and_test_macos.yml
+++ b/.github/workflows/lint_and_test_macos.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/workflow-inference-compiler
           ref: master
-          path: wic
+          path: workflow-inference-compiler
 
       - name: Checkout biobb_adapters
         if: always()
@@ -65,7 +65,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge-pypy3
           miniforge-version: latest
-          environment-file: wic/install/system_deps.yml
+          environment-file: workflow-inference-compiler/install/system_deps.yml
           activate-environment: wic
           use-mamba: true
           channels: conda-forge
@@ -74,11 +74,11 @@ jobs:
       - name: ShellCheck Script Quality
         if: always()
         # "SC1017 (error): Literal carriage return. Run script through tr -d '\r' ."
-        run: shellcheck -e SC1017 $(find wic/ -name "*.sh" -and -not -path "./3/*")
+        run: shellcheck -e SC1017 $(find workflow-inference-compiler/ -name "*.sh" -and -not -path "./3/*")
 
       - name: Install Workflow Inference Compiler
         if: always()
-        run: cd wic/ && pip install ".[all]"
+        run: cd workflow-inference-compiler/ && pip install ".[all]"
 
       - name: Install Molecular Modeling Workflows
         if: always()
@@ -91,23 +91,24 @@ jobs:
 
       - name: Build Documentation
         if: always()
-        run: cd wic/docs && make html
+        run: cd workflow-inference-compiler/docs && make html
 
       - name: MyPy Check Type Annotations
         if: always()
-        run: cd wic/ && mypy src/ examples/ tests/
+        run: cd workflow-inference-compiler/ && mypy src/ examples/ tests/
         # NOTE: Do not use `mypy .` because then mypy will check both src/ and build/ causing:
-        # src/wic/__init__.py: error: Duplicate module named "wic" (also at "./build/lib/wic/__init__.py")
+        # src/workflow-inference-compiler/__init__.py: error: Duplicate module named "wic"
+        # (also at "./build/lib/workflow-inference-compiler/__init__.py")
 
       - name: PyLint Check Code Quality
         if: always()
-        run: cd wic/ && pylint src/ examples/**/*.py tests/
+        run: cd workflow-inference-compiler/ && pylint src/ examples/**/*.py tests/
         # NOTE: See fail-under threshold in .pylintrc
 
       - name: PEP8 Code Formatting
         if: always()
         id: autopep8
-        run: cd wic/ && autopep8 --exit-code --recursive --diff --max-line-length 120 examples/ src/ tests/
+        run: cd workflow-inference-compiler/ && autopep8 --exit-code --recursive --diff --max-line-length 120 examples/ src/ tests/
       - name: Fail if autopep8 made changes
         if: steps.autopep8.outputs.exit-code == 2
         run: exit 1
@@ -116,12 +117,12 @@ jobs:
 
       - name: PyTest CWL Embedding Independence
         if: always()
-        run: cd wic/ && pytest -k test_cwl_embedding_independence # --cov --cov-config=.coveragerc_serial
+        run: cd workflow-inference-compiler/ && pytest -k test_cwl_embedding_independence # --cov --cov-config=.coveragerc_serial
         # NOTE: This test MUST be run in serial! See is_isomorphic_with_timeout()
         timeout-minutes: 5 # backup timeout for windows
 
       - name: PyTest Inline Subworkflows
         if: always()
-        run: cd wic/ && pytest -k test_inline_subworkflows # --cov --cov-config=.coveragerc_serial
+        run: cd workflow-inference-compiler/ && pytest -k test_inline_subworkflows # --cov --cov-config=.coveragerc_serial
         # NOTE: This test MUST be run in serial! See is_isomorphic_with_timeout()
         timeout-minutes: 5 # backup timeout for windows

--- a/.github/workflows/run_workflows.yml
+++ b/.github/workflows/run_workflows.yml
@@ -73,7 +73,7 @@ jobs:
       with:
         repository: ${{ inputs.wic_owner }}/workflow-inference-compiler
         ref: ${{ inputs.wic_ref }}
-        path: wic
+        path: workflow-inference-compiler
 
     - name: Checkout biobb_adapters
       if: always()
@@ -99,7 +99,7 @@ jobs:
     # Using pypy increases performance / decreases cwltool runtime by about a minute.
     - name: Append pypy to conda environment files
       if: runner.os != 'Windows'
-      run: cd wic/install/ && echo "  - pypy" >> system_deps.yml
+      run: cd workflow-inference-compiler/install/ && echo "  - pypy" >> system_deps.yml
 
     - name: Remove old mamba environment
       if: always()
@@ -118,7 +118,7 @@ jobs:
       with:
         miniforge-variant: Mambaforge-pypy3
         miniforge-version: latest
-        environment-file: wic/install/system_deps.yml
+        environment-file: workflow-inference-compiler/install/system_deps.yml
         activate-environment: wic_github_actions
         use-mamba: true
         channels: conda-forge
@@ -131,7 +131,7 @@ jobs:
 
     - name: Install Workflow Inference Compiler
       if: always()
-      run: cd wic/ && pip install ".[all]"
+      run: cd workflow-inference-compiler/ && pip install ".[all]"
 
     - name: Install Molecular Modeling Workflows
       if: always()
@@ -145,7 +145,7 @@ jobs:
     - name: PyTest Run Workflows
       if: always()
       # NOTE: Do NOT add coverage to PYPY CI runs https://github.com/tox-dev/tox/issues/2252
-      run: cd wic/ && pytest -k test_run_workflows_on_push --workers 8 --cwl_runner cwltool # --cov
+      run: cd workflow-inference-compiler/ && pytest -k test_run_workflows_on_push --workers 8 --cwl_runner cwltool # --cov
 
     # NOTE: The steps below are for repository_dispatch only. For all other steps, please insert above
     # this comment.
@@ -183,7 +183,7 @@ jobs:
       # https://github.com/actions/runner/issues/834#issuecomment-907096707
       # Use inputs.sender_repo to reply the original sender.
       if: always()
-      uses: ./wic/.github/my_actions/reply_sender/ # Must start with ./
+      uses: ./workflow-inference-compiler/.github/my_actions/reply_sender/ # Must start with ./
       with:
         github_repository: ${{ github.repository }}
         event_type: ${{ inputs.event_type }}

--- a/.github/workflows/run_workflows_weekly.yml
+++ b/.github/workflows/run_workflows_weekly.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         repository: ${{ github.repository_owner }}/workflow-inference-compiler
         ref: master
-        path: wic
+        path: workflow-inference-compiler
 
     - name: Checkout biobb_adapters
       if: always()
@@ -70,7 +70,7 @@ jobs:
     # Toil is currently incompatible with pypy
     # - name: Append pypy to conda environment files
     #   if: runner.os != 'Windows'
-    #   run: cd wic/install/ && echo "  - pypy" >> system_deps.yml
+    #   run: cd workflow-inference-compiler/install/ && echo "  - pypy" >> system_deps.yml
 
     - name: Setup mamba (linux, macos)
       if: always()
@@ -82,7 +82,7 @@ jobs:
         # another environment, better to avoid the problem altogether by
         # not using Mambaforge-pypy3
         miniforge-version: latest
-        environment-file: wic/install/system_deps.yml
+        environment-file: workflow-inference-compiler/install/system_deps.yml
         activate-environment: wic_github_actions
         use-mamba: true
         channels: conda-forge
@@ -95,7 +95,7 @@ jobs:
 
     - name: Install Workflow Inference Compiler
       if: always()
-      run: cd wic/ && pip install ".[all]"
+      run: cd workflow-inference-compiler/ && pip install ".[all]"
 
     - name: Install Molecular Modeling Workflows
       if: always()
@@ -106,19 +106,19 @@ jobs:
     - name: PyTest Run Workflows (On Push)
       if: always()
       # NOTE: Do NOT add coverage to PYPY CI runs https://github.com/tox-dev/tox/issues/2252
-      run: cd wic/ && pytest -k test_run_workflows_on_push --workers 8 --cwl_runner toil-cwl-runner # --cov
+      run: cd workflow-inference-compiler/ && pytest -k test_run_workflows_on_push --workers 8 --cwl_runner toil-cwl-runner # --cov
 
     - name: PyTest Run Inlined Workflows
       if: always()
       # NOTE: Do NOT add coverage to PYPY CI runs https://github.com/tox-dev/tox/issues/2252
-      run: cd wic/ && pytest -k test_run_inlined_workflows_on_push --workers 8 --cwl_runner toil-cwl-runner # --cov
+      run: cd workflow-inference-compiler/ && pytest -k test_run_inlined_workflows_on_push --workers 8 --cwl_runner toil-cwl-runner # --cov
 
     - name: PyTest Run Workflows (Weekly)
       if: always()
       # NOTE: Do NOT add coverage to PYPY CI runs https://github.com/tox-dev/tox/issues/2252
-      run: cd wic/ && pytest -k test_run_workflows_weekly --workers 8 --cwl_runner toil-cwl-runner # --cov
+      run: cd workflow-inference-compiler/ && pytest -k test_run_workflows_weekly --workers 8 --cwl_runner toil-cwl-runner # --cov
 
     - name: PyTest Run Inlined Workflows (Weekly)
       if: always()
       # NOTE: Do NOT add coverage to PYPY CI runs https://github.com/tox-dev/tox/issues/2252
-      run: cd wic/ && pytest -k test_run_inlined_workflows_weekly --workers 8 --cwl_runner toil-cwl-runner # --cov
+      run: cd workflow-inference-compiler/ && pytest -k test_run_inlined_workflows_weekly --workers 8 --cwl_runner toil-cwl-runner # --cov


### PR DESCRIPTION
Although wic/ is a convenient shorthand for the CI files, some code assumes repo name == relative path. For example:

https://github.com/PolusAI/workflow-inference-compiler/pull/149/files#diff-7e4c248a839c6e16565d109ba53b6bb0c05d29afa622164b48ba54c318c94c61R11