### PR TITLE
consistently set up mamba in lint_and_test workflow on Windows, Mac and Linux

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -131,14 +131,14 @@ jobs:
           miniforge-version: latest
           environment-file: workflow-inference-compiler/install/system_deps.yml
           activate-environment: wic
-          use-mamba: true
           channels: conda-forge
           python-version: "3.9.*" # pypy is not yet compatible with 3.10 and 3.11
 
-      - name: Setup conda (windows)
+      - name: Setup mamba (windows)
         if: runner.os == 'Windows'
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
+          miniforge-variant: Mambaforge-pypy3
           miniforge-version: latest
           environment-file: workflow-inference-compiler/install/system_deps_windows.yml
           activate-environment: wic


### PR DESCRIPTION
Exact same Mamba setup for all three platforms.