### PR TITLE
create py.typed stub for wic and clean up some lint warnings

### DIFF
--- a/src/wic/api/pythonapi.py
+++ b/src/wic/api/pythonapi.py
@@ -354,7 +354,7 @@ class Workflow:
         # self.path = '.' this will overwrite them!
         # self._save_all_cwl()
         self._save_yaml()
-        logger.info("Compiling %s", self.name)
+        logger.info(f"Compiling {self.name}")
         args = ["wic", "--yaml", f"{self.name}.yml"]
         if run_local:
             args.append('--run_local')
@@ -376,5 +376,5 @@ class Workflow:
 
     def run(self, debug: bool = False) -> None:
         """Run compiled workflow."""
-        logger.info("Running %s", self.name)
+        logger.info(f"Running {self.name}")
         self.compile(run_local=True)

--- a/src/wic/api/pythonapi.py
+++ b/src/wic/api/pythonapi.py
@@ -1,6 +1,5 @@
 """CLT utilities."""
 import logging
-import os
 import subprocess
 from dataclasses import dataclass, field
 from functools import singledispatch
@@ -355,7 +354,7 @@ class Workflow:
         # self.path = '.' this will overwrite them!
         # self._save_all_cwl()
         self._save_yaml()
-        logger.info(f"Compiling {self.name}")
+        logger.info("Compiling %s", self.name)
         args = ["wic", "--yaml", f"{self.name}.yml"]
         if run_local:
             args.append('--run_local')
@@ -377,5 +376,5 @@ class Workflow:
 
     def run(self, debug: bool = False) -> None:
         """Run compiled workflow."""
-        logger.info(f"Running {self.name}")
+        logger.info("Running %s", self.name)
         self.compile(run_local=True)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -27,8 +27,8 @@ def get_args(yaml_path: str = '', cwl_inline_subworkflows: bool = False) -> argp
         testargs.append("--cwl_inline_subworkflows")
     # For now, we need to enable --cwl_output_intermediate_files. See comment in compiler.py
     with patch.object(sys, 'argv', testargs):
-        largs: argparse.Namespace = wic.cli.parser.parse_args()
-    return largs
+        args: argparse.Namespace = wic.cli.parser.parse_args()
+    return args
 
 
 args = get_args()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,8 +1,6 @@
 import argparse
 import sys
-from pathlib import Path
 import time
-from pathlib import Path
 from typing import Dict
 from unittest.mock import patch
 
@@ -29,8 +27,8 @@ def get_args(yaml_path: str = '', cwl_inline_subworkflows: bool = False) -> argp
         testargs.append("--cwl_inline_subworkflows")
     # For now, we need to enable --cwl_output_intermediate_files. See comment in compiler.py
     with patch.object(sys, 'argv', testargs):
-        args: argparse.Namespace = wic.cli.parser.parse_args()
-    return args
+        largs: argparse.Namespace = wic.cli.parser.parse_args()
+    return largs
 
 
 args = get_args()


### PR DESCRIPTION
This lets mypy type-infer wic and its submodules. I have also cleaned up some lint warnings. I didn't include URLs in the source because vscode-pylint  already directs one to appropriate PEP with URL when there is a problem. 