### PR TITLE
fix conda/mamba env path for setup-miniconda v3

### DIFF
--- a/.github/workflows/run_workflows.yml
+++ b/.github/workflows/run_workflows.yml
@@ -113,7 +113,7 @@ jobs:
 
     - name: Remove old mamba environment
       if: always()
-      run: rm -rf "/home/$(whoami)/actions-runner/_work/workflow-inference-compiler/workflow-inference-compiler/3/envs/wic_github_actions/"
+      run: rm -rf "/home/$(whoami)/miniconda3/envs/wic_github_actions/"
       # For self-hosted runners, make sure we install into a new mamba environment
       # NOTE: Every time the github self-hosted runner executes, it sets "set -e" in ~/.bash_profile
       # So if we rm -rf the old mamba environment without also removing the mamba init code in ~/.bash_profile

--- a/.github/workflows/run_workflows_weekly.yml
+++ b/.github/workflows/run_workflows_weekly.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Remove old mamba environment
       if: always()
-      run: rm -rf "/home/$(whoami)/actions-runner/_work/workflow-inference-compiler/workflow-inference-compiler/3/envs/wic_github_actions/"
+      run: rm -rf "/home/$(whoami)/miniconda3/envs/wic_github_actions/"
       # For self-hosted runners, make sure we install into a new mamba environment
 
     # Toil is currently incompatible with pypy


### PR DESCRIPTION
https://github.com/conda-incubator/setup-miniconda/pull/299/files

It appears that with setup-miniconda v3, the default conda installation directory has now changed.