### PR TITLE
remove pytest short circuit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,8 +218,7 @@ markers = [
     "slow: (i.e. for medium speed, use 'pytest -m \"not slow\"')",
     "serial: (These tests CANNOT be run in parallel with --workers n > 1)",
 ]
-addopts = "--maxfail=2"
-# Exit after first num failures or errors
+addopts = ""
 
 
 [tool.codespell]


### PR DESCRIPTION
This PR removes the short circuiting behavior in pytest. The only reason we had this was because our CI used to take ~1 hour. Through a series of optimizations, our CI now takes ~10 mins, so this is no longer necessary.

More importantly, since we are using pytest --parallel, there is a race condition where only the first two errors are shown, which can be misleading.