### PR TITLE
drop pydantic v1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,8 @@ repos:
     hooks:
     -   id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
-        additional_dependencies: # Copied from setup.cfg
+        additional_dependencies: # Copied from pyproject.toml
+        - pydantic  # so we can enable the pydantic.mypy plugin
         - lxml-stubs
         - types-Pillow
         - types-PyYAML
@@ -60,6 +61,7 @@ repos:
         - types-docutils
         - types-jsonschema
         - types-psutil
+        - types-html5lib
         - types-python-jose
         - types-pytz
         - types-redis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "beautifulsoup4", # Solely for parsing gromacs mdp options html
     "cwl-utils>=0.31", # CommandInputParameter attr changed from `type_` to `type` https://github.com/common-workflow-language/cwl-utils/releases/tag/v0.31
     "typeguard",
-    "pydantic>=1.10.11"
+    "pydantic>=2.6"
 ]
 
 [project.readme]
@@ -73,6 +73,7 @@ mypy-types = [
     "types-colorama",
     "types-decorator",
     "types-docutils",
+    "types-html5lib",
     "types-jsonschema",
     "types-psutil",
     "types-python-jose",
@@ -144,6 +145,9 @@ source_dir = "docs"
 # Based on https://packaging.python.org/en/latest/tutorials/packaging-projects/
 
 [tool.mypy]
+# See https://docs.pydantic.dev/latest/integrations/mypy/#enabling-the-plugin
+plugins = ["pydantic.mypy"]
+
 # See https://mypy.readthedocs.io/en/stable/running_mypy.html#follow-imports
 follow_imports = "normal"
 

--- a/src/wic/api/_compat.py
+++ b/src/wic/api/_compat.py
@@ -1,3 +1,0 @@
-import pydantic
-
-PYDANTIC_V2 = pydantic.VERSION.startswith("2.")


### PR DESCRIPTION
This PR drops pydantic version 1 support, for the following reasons:

1. We simply do not need to support it in this repository. WIC is independent of the other PolusAI repos, and should not need to be installed simultaneously with any projects that require pydantic version 1, but not version 2.
2. Attempting to support both versions causes spurious mypy errors in the pre-commit hooks.

mypy has the ability to [support multiple operating systems and multiple versions of python](https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks) itself, but that ability does NOT extend to python dependencies. In particular, while the following code works at runtime
```
if PYDANTIC_V2:
    ...
else:
    ...
```
in general it is not possible for static analysis tools (mypy is just one example) to evaluate conditionals.
(Static analysis does not perform evaluation; that's what makes it static!)

So since mypy cannot determine which branch is taken, it attempts to perform static analysis on both branches simultaneously, which will always generate an error when there are breaking changes in an API.

Hopefully this clears up the confusion discussed in the previous PR #170.