### PR TITLE
do not re-export

### DIFF
--- a/src/wic/api/__init__.py
+++ b/src/wic/api/__init__.py
@@ -1,3 +1,0 @@
-from .pythonapi import Step, Workflow
-
-__all__ = ["Step", "Workflow"]


### PR DESCRIPTION
In python, re-exporting can cause a cascading import situation, which can unnecessarily force all runtime dependencies to be build dependencies. See this [recent concrete example](https://github.com/PolusAI/bfio/pull/68/files#r1471591950).

This PR removes all re-exports, so we nip this problem in the bud, before users depend on the aliases. i.e.
Instead of
`from wic.api import Step, Workflow`
users should use
`from wic.api.pythonapi import Step, Workflow`

This has the added benefit of suggesting the idea that there are other kinds of APIs.