### PR TITLE
extract hardcoded nonportable paths from Workflow Steps

### DIFF
--- a/src/wic/api/pythonapi.py
+++ b/src/wic/api/pythonapi.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import subprocess as sub
 from typing import Any, ClassVar, Optional, TypeVar, Union
 
+from mergedeep import merge, Strategy
 import cwl_utils.parser as cu_parser
 import yaml
 from cwl_utils.parser import CommandLineTool as CWLCommandLineTool
@@ -379,8 +380,9 @@ class Workflow:
         # We do NOT need to save anything to disk
         # If we don't care about portability,
         # we also don't need to READ anything from disk.
-        # tools_cwl: Tools = plugins.get_tools_cwl(args.homedir, quiet=args.quiet)
-        tools_cwl: Tools = extract_tools_paths_NONPORTABLE(self.steps)
+        tools_disk: Tools = plugins.get_tools_cwl(args.homedir, quiet=args.quiet)
+        tools_steps: Tools = extract_tools_paths_NONPORTABLE(self.steps)
+        tools_cwl = merge(tools_disk, tools_steps, strategy=Strategy.TYPESAFE_REPLACE)
 
         # The compile_workflow function is 100% in-memory
         compiler_info = compiler.compile_workflow(yaml_tree, args, [], [graph], {}, {}, {}, {},


### PR DESCRIPTION
Since
1. there continues to be resistance to the [auto-discovery](https://workflow-inference-compiler.readthedocs.io/en/latest/userguide.html#auto-discovery) mechanism (read: resistance to using config files in ~/wic/ because doing anything other than foo.bar.baz.quux is "not pythonic" and verboten), and since
2. there still appears to be a lack of understanding that the only thing that is actually necessary is to construct a `Tools` dictionary using any means necessary, 
3. this PR demonstrates how to extract a Tools dictionary _in a single line of code_ from the Steps in a Workflow object.
Note that the extracted hardcoded paths are non-portable, and the function has been named accordingly.

Again, the only thing that matters is that we have a Tools dictionary to pass into the compile_workflow function. As this PR demonstrates, it is absolutely trivial to construct a Tools dictionary, so if you don't like either of these two methods then by all means create your own and open a PR.