### PR TITLE
partial codes range for partial failures

### DIFF
--- a/src/sophios/cli.py
+++ b/src/sophios/cli.py
@@ -64,6 +64,9 @@ parser.add_argument('--partial_failure_enable', default=False, action="store_tru
 parser.add_argument('--partial_failure_success_codes', nargs='*', type=int, default=[0, 1], required=False,
                     help='Let users add custom error codes to be treated as success')
 
+parser.add_argument('--partial_failure_success_codes_range', nargs=2, type=int, default=[0, 1], required=False,
+                    help='Let users add custom error code range to be treated as success')
+
 group_run = parser.add_mutually_exclusive_group()
 group_run.add_argument('--generate_run_script', default=False, action="store_true",
                        help='Just generates run.sh and exits. Does not actually invoke ./run.sh')

--- a/src/sophios/plugins.py
+++ b/src/sophios/plugins.py
@@ -156,7 +156,12 @@ def cwl_update_outputs_optional(cwl: Cwl) -> Cwl:
     # default value of cwl_mod['successCodes'] = 0 and 'partial_failure_success_codes' = [0,1]
     # take the Union of 0 and partial_failure_success_codes, the 'successCodes' might not be set
     # never discard 0 (actual success)
-    cwl_mod['successCodes'] = list(set([0] + args.partial_failure_success_codes))
+    failure_code_range = args.partial_failure_success_codes_range
+    codes_from_range = list(range(failure_code_range[0], failure_code_range[1]))
+    direct_failure_codes = args.partial_failure_success_codes
+    assert failure_code_range[0] <= failure_code_range[1], \
+        f"lower {failure_code_range[0]}  value can't be greater than higher {failure_code_range[1]} value"
+    cwl_mod['successCodes'] = list(set([0] + direct_failure_codes + codes_from_range))
     # Update outputs optional
     for out_key, out_val_dict in cwl_mod['outputs'].items():
         if isinstance(out_val_dict['type'], str) and out_val_dict['type'][-1] != '?':


### PR DESCRIPTION
This lets the user to specify a range of error code to be treated as success by --partial_failure_enable