### PR TITLE
Fix PyPy Docker build process

### DIFF
--- a/docker/Dockerfile_amazon_pypy
+++ b/docker/Dockerfile_amazon_pypy
@@ -27,6 +27,7 @@ WORKDIR /workflow-inference-compiler
 # wic within a conda environment. Let's just install it globally!
 RUN mamba env update --name base --file install/pypy.yml
 RUN mamba env update --name base --file install/system_deps.yml
+RUN mamba env update --name base --file install/pypy_docker_deps.yml
 RUN pip install -e ".[all_except_runner_src]"
 
 RUN mamba clean --all --yes

--- a/docker/Dockerfile_debian_pypy
+++ b/docker/Dockerfile_debian_pypy
@@ -27,6 +27,7 @@ WORKDIR /workflow-inference-compiler
 # wic within a conda environment. Let's just install it globally!
 RUN mamba env update --name base --file install/pypy.yml
 RUN mamba env update --name base --file install/system_deps.yml
+RUN mamba env update --name base --file install/pypy_docker_deps.yml
 RUN pip install -e ".[all_except_runner_src]"
 
 RUN mamba clean --all --yes

--- a/docker/Dockerfile_fedora_pypy
+++ b/docker/Dockerfile_fedora_pypy
@@ -27,6 +27,7 @@ WORKDIR /workflow-inference-compiler
 # wic within a conda environment. Let's just install it globally!
 RUN mamba env update --name base --file install/pypy.yml
 RUN mamba env update --name base --file install/system_deps.yml
+RUN mamba env update --name base --file install/pypy_docker_deps.yml
 RUN pip install -e ".[all_except_runner_src]"
 
 RUN mamba clean --all --yes

--- a/docker/Dockerfile_redhat_pypy
+++ b/docker/Dockerfile_redhat_pypy
@@ -28,6 +28,7 @@ WORKDIR /workflow-inference-compiler
 # wic within a conda environment. Let's just install it globally!
 RUN mamba env update --name base --file install/pypy.yml
 RUN mamba env update --name base --file install/system_deps.yml
+RUN mamba env update --name base --file install/pypy_docker_deps.yml
 RUN pip install -e ".[all_except_runner_src]"
 
 RUN mamba clean --all --yes

--- a/docker/Dockerfile_ubuntu_pypy
+++ b/docker/Dockerfile_ubuntu_pypy
@@ -27,6 +27,7 @@ WORKDIR /workflow-inference-compiler
 # wic within a conda environment. Let's just install it globally!
 RUN mamba env update --name base --file install/pypy.yml
 RUN mamba env update --name base --file install/system_deps.yml
+RUN mamba env update --name base --file install/pypy_docker_deps.yml
 RUN pip install -e ".[all_except_runner_src]"
 
 RUN mamba clean --all --yes

--- a/install/pypy_docker_deps.yml
+++ b/install/pypy_docker_deps.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - psutil==5.9.8
+  - httptools


### PR DESCRIPTION
Currently with new release of psutils (6.0.0), cwl-tools dependency of psutil (<6, >3.1) is not met and hence needed separate installation. 
Also, httptools lack PyPy wheel and so needed to be installed via conda. 